### PR TITLE
Add the ability to copy workouts.

### DIFF
--- a/app/src/main/java/com/sdrockstarstudios/meatheadandroid/CopyWorkoutDialogFragment.java
+++ b/app/src/main/java/com/sdrockstarstudios/meatheadandroid/CopyWorkoutDialogFragment.java
@@ -1,0 +1,89 @@
+package com.sdrockstarstudios.meatheadandroid;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Spinner;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import java.util.List;
+
+public class CopyWorkoutDialogFragment extends DialogFragment {
+
+    private List<String> availableWorkouts;
+    private  String selectedWorkout;
+
+    public String getSelectedWorkout(){ return selectedWorkout; }
+
+
+    public CopyWorkoutDialogFragment(List<String> availableWorkouts){
+        this. availableWorkouts = availableWorkouts;
+    }
+
+    public interface NoticeDialogListener {
+        void onDialogPositiveClick(DialogFragment dialog);
+        void onDialogNegativeClick(DialogFragment dialog);
+    }
+
+    CopyWorkoutDialogFragment.NoticeDialogListener listener;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        try {
+            listener = (CopyWorkoutDialogFragment.NoticeDialogListener) context;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(getActivity().toString() + " must implement NoticeListener");
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        ContextThemeWrapper newContext = new ContextThemeWrapper(getContext(), R.style.popup_dialogs);
+        AlertDialog.Builder builder = new AlertDialog.Builder(newContext);
+        LayoutInflater inflater = requireActivity().getLayoutInflater();
+
+        builder.setView(inflater.inflate(R.layout.dialog_copy_workout, null))
+                .setPositiveButton(R.string.copy_workout_confirm, (dialog, id) ->
+                        listener.onDialogPositiveClick(CopyWorkoutDialogFragment.this))
+                .setNegativeButton(R.string.cancel, (dialog, which) ->
+                        listener.onDialogNegativeClick(CopyWorkoutDialogFragment.this));
+
+        AlertDialog dialog = builder.create();
+
+        // this will need to change to ensure spinner selection has been made.
+        dialog.setOnShowListener(dialogInterface -> {
+            Log.i(this.getClass().toString(), "=========== in setOnShowListener for copy.");
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+            Spinner availableWorkoutSpinner = (Spinner) dialog.findViewById(R.id.available_workouts);
+
+            ArrayAdapter<String> adapter = new ArrayAdapter<String>(getContext(), android.R.layout.simple_spinner_item, availableWorkouts);
+            availableWorkoutSpinner.setAdapter(adapter);
+            availableWorkoutSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+                @Override
+                public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+                    selectedWorkout = (String) parent.getItemAtPosition(position);
+                }
+
+                @Override
+                public void onNothingSelected(AdapterView<?> parent) {
+                    dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
+                }
+            });
+        });
+
+        return dialog;
+    }
+}

--- a/app/src/main/java/com/sdrockstarstudios/meatheadandroid/DeleteExerciseDialogFragment.java
+++ b/app/src/main/java/com/sdrockstarstudios/meatheadandroid/DeleteExerciseDialogFragment.java
@@ -4,12 +4,8 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.os.Bundle;
-import android.text.Editable;
-import android.text.TextWatcher;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
-import android.view.View;
-import android.widget.EditText;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
@@ -27,8 +23,8 @@ public class DeleteExerciseDialogFragment extends DialogFragment {
     }
 
     public interface NoticeDialogListener {
-        public void onDialogPositiveClick(DialogFragment dialog);
-        public void onDialogNegativeClick(DialogFragment dialog);
+        void onDialogPositiveClick(DialogFragment dialog);
+        void onDialogNegativeClick(DialogFragment dialog);
     }
 
     DeleteExerciseDialogFragment.NoticeDialogListener listener;

--- a/app/src/main/java/com/sdrockstarstudios/meatheadandroid/WorkoutLogActivity.java
+++ b/app/src/main/java/com/sdrockstarstudios/meatheadandroid/WorkoutLogActivity.java
@@ -299,7 +299,7 @@ public class WorkoutLogActivity extends AppCompatActivity
             });
 
             exerciseLabelTextView.setOnLongClickListener(v -> {
-                delete_exercise(horScrollViewLinearLayout.getId());
+                delete_exercise(exerciseContainer.getId());
                 return false;
             });
         }

--- a/app/src/main/res/layout/activity_workout_log_menu.xml
+++ b/app/src/main/res/layout/activity_workout_log_menu.xml
@@ -21,7 +21,7 @@
         android:id="@+id/newWorkoutButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="40dp"
+        android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="60dp"
         android:onClick="pressNewWorkoutButton"
@@ -36,19 +36,39 @@
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.5" />
+        app:layout_constraintGuide_percent="0.3333333333" />
 
     <Button
         android:id="@+id/loadWorkoutButton"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
-        android:layout_marginEnd="40dp"
+        android:layout_marginEnd="8dp"
         android:layout_marginBottom="60dp"
         android:text="Load Workout"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@id/guideline2"
         app:layout_constraintStart_toStartOf="@+id/guideline"
+        app:layout_constraintWidth_max="200dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent=".66666666666666666" />
+
+    <Button
+        android:id="@+id/copyWorkoutButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="60dp"
+        android:text="Copy Workout"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@id/guideline2"
         app:layout_constraintWidth_max="200dp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_copy_workout.xml
+++ b/app/src/main/res/layout/dialog_copy_workout.xml
@@ -1,0 +1,21 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:theme="@style/popup_dialogs">
+
+    <Spinner
+        android:id="@+id/available_workouts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+    <!--    <EditText-->
+    <!--        android:id="@+id/exercise_name_entry"-->
+    <!--        android:inputType="text"-->
+    <!--        android:layout_width="match_parent"-->
+    <!--        android:layout_height="wrap_content"-->
+    <!--        android:layout_marginTop="16dp"-->
+    <!--        android:layout_marginLeft="4dp"-->
+    <!--        android:layout_marginRight="4dp"-->
+    <!--        android:layout_marginBottom="4dp"-->
+    <!--        android:hint="@string/workout_name" />-->
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_copy_workout.xml
+++ b/app/src/main/res/layout/dialog_copy_workout.xml
@@ -8,14 +8,4 @@
         android:id="@+id/available_workouts"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
-    <!--    <EditText-->
-    <!--        android:id="@+id/exercise_name_entry"-->
-    <!--        android:inputType="text"-->
-    <!--        android:layout_width="match_parent"-->
-    <!--        android:layout_height="wrap_content"-->
-    <!--        android:layout_marginTop="16dp"-->
-    <!--        android:layout_marginLeft="4dp"-->
-    <!--        android:layout_marginRight="4dp"-->
-    <!--        android:layout_marginBottom="4dp"-->
-    <!--        android:hint="@string/workout_name" />-->
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="delete">Delete</string>
     <string name="cancel">Cancel</string>
     <string name="load_workout_confirm">Load</string>
+    <string name="copy_workout_confirm">Copy</string>
     <string name="meatheadBanner">MeatHead</string>
     <string name="end_workout_button_text">End Workout</string>
     <string name="end_workout_confirm">End</string>


### PR DESCRIPTION
This change adds the ability to copy workouts. A new workout is created with the same name and all of the same workouts under a different workout UUID but excludes all of the set data. From there the user is able to use and modify the workout as they want. 

It also fixes the bug where deleting an exercise from a loaded or copied exercise causes the app to crash due to accessing the wrong View. 